### PR TITLE
fix(config): prevent configured apiKey from being lost

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.hmydk"
-version = "1.2.0"
+version = "1.2.1"
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/hmydk/aigit/config/ApiKeySettings.java
+++ b/src/main/java/com/hmydk/aigit/config/ApiKeySettings.java
@@ -29,9 +29,7 @@ public class ApiKeySettings implements PersistentStateComponent<ApiKeySettings> 
     // current prompt by user choose
     private PromptInfo customPrompt = new PromptInfo("", "");
 
-    private Map<String, ModuleConfig> moduleConfigs = new HashMap<>(){{
-        putAll(Constants.moduleConfigs);
-    }};
+    private Map<String, ModuleConfig> moduleConfigs = new HashMap<>();
 
     public static ApiKeySettings getInstance() {
         return ApplicationManager.getApplication().getService(ApiKeySettings.class);

--- a/src/main/java/com/hmydk/aigit/config/ModuleConfigDialog.java
+++ b/src/main/java/com/hmydk/aigit/config/ModuleConfigDialog.java
@@ -20,6 +20,9 @@ import org.jetbrains.annotations.Nullable;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.net.URI;
 import java.util.Map;
 
 public class ModuleConfigDialog extends DialogWrapper {
@@ -104,6 +107,19 @@ public class ModuleConfigDialog extends DialogWrapper {
 
     private void updateHelpText() {
         helpLabel.setText(Constants.getHelpText(client));
+        if (client.equals(Constants.Gemini)){
+            helpLabel.setCursor(new Cursor(Cursor.HAND_CURSOR));
+            helpLabel.addMouseListener(new MouseAdapter() {
+                @Override
+                public void mouseClicked(MouseEvent e) {
+                    try {
+                        Desktop.getDesktop().browse(new URI("https://aistudio.google.com/app/apikey"));
+                    } catch (Exception ex) {
+                        ex.printStackTrace();
+                    }
+                }
+            });
+        }
     }
 
     @Override
@@ -178,7 +194,13 @@ public class ModuleConfigDialog extends DialogWrapper {
         ApiKeySettings settings = ApiKeySettings.getInstance();
         String configKey = client;
         ApiKeySettings.ModuleConfig moduleConfig = settings.getModuleConfigs()
-                .computeIfAbsent(configKey, k -> new ApiKeySettings.ModuleConfig());
+                .computeIfAbsent(configKey, k -> {
+                    ApiKeySettings.ModuleConfig defaultConfig = Constants.moduleConfigs.get(configKey);
+                    ApiKeySettings.ModuleConfig config = new ApiKeySettings.ModuleConfig();
+                    config.setUrl(defaultConfig.getUrl());
+                    config.setApiKey(defaultConfig.getApiKey());
+                    return config;
+                });
         urlField.setText(moduleConfig.getUrl());
         apiKeyField.setText(moduleConfig.getApiKey());
     }

--- a/src/main/java/com/hmydk/aigit/constant/Constants.java
+++ b/src/main/java/com/hmydk/aigit/constant/Constants.java
@@ -51,7 +51,8 @@ public class Constants {
 
     public static String getHelpText(String client) {
         return switch (client) {
-            case Gemini -> "Get your API key from Google AI Studio (https://aistudio.google.com/app/apikey)";
+//            case Gemini -> "Get your API key from Google AI Studio (https://aistudio.google.com/app/apikey)";
+            case Gemini -> "<html>Get your API key from <a href='https://aistudio.google.com/app/apikey'>Google AI Studio</a></html>";
             case Ollama -> "Make sure Ollama is running locally on the specified URL";
             default -> "";
         };

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -50,9 +50,13 @@
 
     <change-notes>
         <![CDATA[
-        <h4>Feature:</h4>
+        <h3>Fixed:</h3>
         <ul>
-            <li>Support Ollama as LLM client.</li>
+            <li>Fix the issue that the configured apiKey is lost.</li>
+        </ul>
+        <h3>Added:</h3>
+        <ul>
+            <li>Add a link to get the Gemini API key.</li>
         </ul>
         ]]>
     </change-notes>


### PR DESCRIPTION
• Update the `ApiKeySettings` class to ensure that the configured API key is not lost when the module is reconfigured. #14 
• Add a link to get the Gemini API key in the module config dialog. 
• Modify the `Constants` class to include the link for the Gemini API key.