### PR TITLE
feat: Add compatibility support for IntelliJ IDEA build 252* and newer versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.hmydk"
-version = "1.5.7"
+version = "1.5.8"
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.hmydk"
-version = "1.5.6"
+version = "1.5.7"
 
 repositories {
     mavenCentral()
@@ -20,7 +20,7 @@ intellij {
 }
 
 patchPluginXml.sinceBuild.set("241.0")
-patchPluginXml.untilBuild.set("251.*")
+patchPluginXml.untilBuild.set("253.*")
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.hmydk"
-version = "1.5.5"
+version = "1.5.6"
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id("java")
-    id("org.jetbrains.intellij") version "1.17.3"
+    id("org.jetbrains.intellij") version "1.17.4"
 }
 
 group = "com.hmydk"
@@ -19,8 +19,8 @@ intellij {
     plugins = ["Git4Idea", "java"]
 }
 
-patchPluginXml.sinceBuild.set("231.8109.175")
-patchPluginXml.untilBuild.set("243.*")
+patchPluginXml.sinceBuild.set("241.0")
+patchPluginXml.untilBuild.set("251.*")
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -71,7 +71,7 @@
 
     <actions>
         <!-- Declare the action for manual commit message generation -->
-        <action id="AICommitMessage.Generate"
+        <action id="com.hmydk.aigit.GenerateCommitMessageAction"
                 class="com.hmydk.aigit.GenerateCommitMessageAction"
                 text="Generate AI Commit Message"
                 icon="/icons/git-commit-logo.svg"


### PR DESCRIPTION
## 🎯 Overview
This PR adds compatibility support for newer IntelliJ IDEA versions, specifically addressing compatibility issues with IDEA build 251.* 

## 🔧 Changes Made

### 1. **Extended IDEA Compatibility Range**
- Updated `untilBuild` from `243.*` to `253.*` 
- Updated `sinceBuild` from `231.8109.175` to `241.0`
- Now supports IntelliJ IDEA builds from 241.0 to 253.*

### 2. **Infrastructure Improvements** 
- Updated IntelliJ Gradle Plugin from `1.17.3` to `1.17.4`
- Updated Gradle wrapper from `8.7` to `8.10.2` (adds Java 23 support)
- Fixed duplicate icon issue by updating action ID

### 3. **Version Updates**
- Bumped plugin version from `1.5.5` to `1.5.8`
- Added proper semantic versioning and git tags

## ✅ **Testing**
- ✅ Successfully builds with new configuration
- ✅ Tested with IntelliJ IDEA Ultimate build `IU-252.23892.409`
- ✅ Plugin loads correctly without compatibility warnings
- ✅ All AI commit generation features work as expected

## 🐛 **Fixes**
- Resolves compatibility issue: "Plugin is not compatible with the current version of the IDE"
- Fixes duplicate icon display in commit panel
- Eliminates build warnings about platform version mismatches
<img width="671" height="58" alt="aigitcommitfix" src="https://github.com/user-attachments/assets/941f196e-6284-4aab-91f2-b691733c6718" />

## 📋 **Compatibility**
- **Before:** Supports IDEA builds 231.* - 243.*
- **After:** Supports IDEA builds 241.0 - 253.* 
- **Tested on:** IntelliJ IDEA Ultimate 2024.3+ (build 252.*)

## 🔗 **Related Issues**
This addresses compatibility issues for users running newer IntelliJ IDEA versions who encounter the "Plugin is not compatible" error.