### PR TITLE
fix: Duplicate requests caused by multiple clicks on the button

### DIFF
--- a/src/main/java/com/hmydk/aigit/GenerateCommitMessageAction.java
+++ b/src/main/java/com/hmydk/aigit/GenerateCommitMessageAction.java
@@ -83,7 +83,7 @@ public class GenerateCommitMessageAction extends AnAction {
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         Project project = e.getProject();
-        if (project == null) {
+        if (project == null || isGenerating.get()) {
             return;
         }
 


### PR DESCRIPTION
When `generate commit msg` icon is clicked rapidly multiple times, the plugin sends multiple duplicate requests. This PR ensures that a new request can only be initiated after the previous one has been completed.

Before:

https://github.com/user-attachments/assets/50644964-7ab1-4db8-8b70-51bfcf17551a

After:

https://github.com/user-attachments/assets/6ffb7227-7007-43c7-b682-b63e079fde99



